### PR TITLE
Adding gamma plotter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 
 # version file
 openmc_source_plotter/_version.py
+
+# plots
+*.png

--- a/examples/example_gamma_spec_plot.py
+++ b/examples/example_gamma_spec_plot.py
@@ -1,0 +1,15 @@
+import openmc
+import openmc.deplete
+import openmc_source_plotter
+
+openmc.config['chain_file']='chain-endf.xml'
+
+my_material = openmc.Material()
+my_material.add_nuclide('Xe135', 1)
+my_material.volume = 1
+energy_dis= my_material.decay_photon_energy
+
+plt = my_material.plot_gamma_emission(
+        threshold=1.2e19,
+)
+plt.show()

--- a/examples/example_gamma_spec_plot.py
+++ b/examples/example_gamma_spec_plot.py
@@ -6,12 +6,12 @@ import openmc_source_plotter  # adds plot_gamma_emission plot to materials
 openmc.config["chain_file"] = "chain-endf.xml"
 
 my_material = openmc.Material()
-my_material.add_nuclide('Xe135', 1e-12)
-my_material.add_nuclide('U235', 1)
-my_material.add_nuclide('U238', 1)
-my_material.add_nuclide('Co60', 1e-9)
+my_material.add_nuclide("Xe135", 1e-12)
+my_material.add_nuclide("U235", 1)
+my_material.add_nuclide("U238", 1)
+my_material.add_nuclide("Co60", 1e-9)
 my_material.volume = 1
 
 plt = my_material.plot_gamma_emission(label_top=3)
-plt.xscale('log') # modify axis from default settings
-plt.savefig('gamma_spec.png')
+plt.xscale("log")  # modify axis from default settings
+plt.savefig("gamma_spec.png")

--- a/examples/example_gamma_spec_plot.py
+++ b/examples/example_gamma_spec_plot.py
@@ -1,16 +1,17 @@
 import openmc
 import openmc.deplete
-import openmc_source_plotter
+import openmc_source_plotter  # adds plot_gamma_emission plot to materials
+
 
 openmc.config['chain_file']='chain-endf.xml'
 
 my_material = openmc.Material()
 my_material.add_nuclide('Xe135', 1e-12)
 my_material.add_nuclide('U235', 1)
+my_material.add_nuclide('U238', 1)
+my_material.add_nuclide('Co60', 1e-9)
 my_material.volume = 1
-energy_dis= my_material.decay_photon_energy
 
-plt = my_material.plot_gamma_emission(
-        threshold=0.25e7,
-)
-plt.show()
+plt = my_material.plot_gamma_emission(label_top=3)
+plt.xscale('log') # modify axis from default settings
+plt.savefig('gamma_spec.png')

--- a/examples/example_gamma_spec_plot.py
+++ b/examples/example_gamma_spec_plot.py
@@ -5,11 +5,12 @@ import openmc_source_plotter
 openmc.config['chain_file']='chain-endf.xml'
 
 my_material = openmc.Material()
-my_material.add_nuclide('Xe135', 1)
+my_material.add_nuclide('Xe135', 1e-12)
+my_material.add_nuclide('U235', 1)
 my_material.volume = 1
 energy_dis= my_material.decay_photon_energy
 
 plt = my_material.plot_gamma_emission(
-        threshold=1.2e19,
+        threshold=0.25e7,
 )
 plt.show()

--- a/openmc_source_plotter/__init__.py
+++ b/openmc_source_plotter/__init__.py
@@ -14,3 +14,4 @@ except PackageNotFoundError:
 __all__ = ["__version__"]
 
 from .core import Source
+from .material import Material

--- a/openmc_source_plotter/core.py
+++ b/openmc_source_plotter/core.py
@@ -10,6 +10,7 @@ import openmc.lib
 import plotly.graph_objects
 
 
+
 class Source(openmc.Source):
     r"""Inherits and extents the openmc.Source class to add source plotting
     methods for energy, direction and position. Source sampling methods are
@@ -99,7 +100,7 @@ class Source(openmc.Source):
         n_samples: int = 2000,
         prn_seed: int = 1,
     ):
-        """makes a plot of the initial creation postions of an OpenMC source(s)
+        """makes a plot of the initial creation positions of an OpenMC source(s)
 
         Args:
             figure: Optional base plotly figure to use for the plot. Passing in

--- a/openmc_source_plotter/material.py
+++ b/openmc_source_plotter/material.py
@@ -46,9 +46,24 @@ class Material(openmc.Material):
                 energies_to_label.append(entry[2])
                 labels.append(entry[0])
 
+            probs = []
+            en = []
+            energy_dis = self.decay_photon_energy
+            for p in energy_dis.p:
+                probs.append(0)
+                probs.append(p)
+                probs.append(0)
+            for x in energy_dis.x:
+                en.append(x)
+                en.append(x)
+                en.append(x)
+            # print(en)
+            # print(probs)
             lineid_plot.plot_line_ids(
-                self.decay_photon_energy.x,
-                self.decay_photon_energy.p,
+                en,
+                # self.decay_photon_energy.x,
+                probs,
+                # self.decay_photon_energy.p,
                 energies_to_label,
                 labels,
             )
@@ -68,8 +83,8 @@ class Material(openmc.Material):
 
             # plt.scatter(energy_dis.x, energy_dis.p)
             plt.plot(en, probs)
-            print(energy_dis.p)
-            print(energy_dis.x)
+            # print(energy_dis.p)
+            # print(energy_dis.x)
         plt.xlabel("Energy [eV]")
         plt.ylabel("Activity [Bq/s]")
         return plt

--- a/openmc_source_plotter/material.py
+++ b/openmc_source_plotter/material.py
@@ -1,0 +1,50 @@
+import openmc
+import matplotlib.pyplot as plt
+
+
+class Material(openmc.Material):
+
+    def plot_gamma_emission(
+        self,
+        threshold,
+    ):
+        
+        import lineid_plot
+
+        energies_to_label = []
+        labels=[]
+        atoms = self.get_nuclide_atoms()
+        dists = []
+        probs = []
+        for nuc, num_atoms in atoms.items():
+            source_per_atom = openmc.data.decay_photon_energy(nuc)
+            if source_per_atom is not None:
+                # dists.append(source_per_atom)
+                # probs.append(num_atoms)
+                if num_atoms>threshold:
+                    energies_to_label.append(source_per_atom.x)
+                    labels.append(str(source_per_atom.p))
+        # return openmc.data.combine_distributions(dists, probs)
+
+        # ps = self.decay_photon_energy.p
+        # xs = self.decay_photon_energy.x
+
+        # for x,p in zip(xs,ps):
+        #     print(p)
+        #     if p > threshold:
+
+        # print(energies_to_label)
+        # print(labels)
+
+        lineid_plot.plot_line_ids(self.decay_photon_energy.x, self.decay_photon_energy.p, energies_to_label, labels)
+# my_material.nuclides[0]
+# NuclideTuple(name='Xe135', percent=1, percent_type='ao')
+
+        
+        # plt.plot()
+        plt.xlabel('Energy (eV)')
+        # plt.xscale('log')
+        plt.ylabel('Probability')
+        return plt
+
+openmc.Material = Material

--- a/openmc_source_plotter/material.py
+++ b/openmc_source_plotter/material.py
@@ -54,9 +54,22 @@ class Material(openmc.Material):
             )
 
         else:
+            probs = []
+            en = []
             energy_dis = self.decay_photon_energy
-            plt.plot(energy_dis.x, energy_dis.p)
+            for p in energy_dis.p:
+                probs.append(0)
+                probs.append(p)
+                probs.append(0)
+            for x in energy_dis.x:
+                en.append(x)
+                en.append(x)
+                en.append(x)
 
+            # plt.scatter(energy_dis.x, energy_dis.p)
+            plt.plot(en, probs)
+            print(energy_dis.p)
+            print(energy_dis.x)
         plt.xlabel("Energy [eV]")
         plt.ylabel("Activity [Bq/s]")
         return plt

--- a/openmc_source_plotter/material.py
+++ b/openmc_source_plotter/material.py
@@ -15,17 +15,18 @@ class Material(openmc.Material):
         Args:
             label_top: Optionally label the n highest activity energies with
                 the nuclide that generates them.
-        
+
         Returns:
             Matplotlib pyplot object.
         """
-        
+
         plt.clf()
         if label_top:
             energies_to_label = []
-            labels=[]
+            labels = []
             possible_energies_to_label = []
             import lineid_plot
+
             atoms = self.get_nuclide_atoms()
             for nuc, num_atoms in atoms.items():
                 dists = []
@@ -36,21 +37,29 @@ class Material(openmc.Material):
                     probs.append(num_atoms)
                     combo = openmc.data.combine_distributions(dists, probs)
                     for p, x in zip(combo.p, combo.x):
-                        possible_energies_to_label.append((nuc,p,x))
+                        possible_energies_to_label.append((nuc, p, x))
 
-            possible_energies_to_label = sorted(possible_energies_to_label, key=lambda x: x[1], reverse=True)[:label_top]
+            possible_energies_to_label = sorted(
+                possible_energies_to_label, key=lambda x: x[1], reverse=True
+            )[:label_top]
             for entry in possible_energies_to_label:
                 energies_to_label.append(entry[2])
                 labels.append(entry[0])
 
-            lineid_plot.plot_line_ids(self.decay_photon_energy.x, self.decay_photon_energy.p, energies_to_label, labels)
+            lineid_plot.plot_line_ids(
+                self.decay_photon_energy.x,
+                self.decay_photon_energy.p,
+                energies_to_label,
+                labels,
+            )
 
         else:
             energy_dis = self.decay_photon_energy
             plt.plot(energy_dis.x, energy_dis.p)
 
-        plt.xlabel('Energy [eV]')
-        plt.ylabel('Activity [Bq/s]')
+        plt.xlabel("Energy [eV]")
+        plt.ylabel("Activity [Bq/s]")
         return plt
+
 
 openmc.Material = Material

--- a/openmc_source_plotter/material.py
+++ b/openmc_source_plotter/material.py
@@ -14,31 +14,23 @@ class Material(openmc.Material):
         energies_to_label = []
         labels=[]
         atoms = self.get_nuclide_atoms()
-        dists = []
-        probs = []
         for nuc, num_atoms in atoms.items():
+            dists = []
+            probs = []
+            print(nuc)
             source_per_atom = openmc.data.decay_photon_energy(nuc)
             if source_per_atom is not None:
-                # dists.append(source_per_atom)
-                # probs.append(num_atoms)
-                if num_atoms>threshold:
-                    energies_to_label.append(source_per_atom.x)
-                    labels.append(str(source_per_atom.p))
-        # return openmc.data.combine_distributions(dists, probs)
-
-        # ps = self.decay_photon_energy.p
-        # xs = self.decay_photon_energy.x
-
-        # for x,p in zip(xs,ps):
-        #     print(p)
-        #     if p > threshold:
-
-        # print(energies_to_label)
-        # print(labels)
+                dists.append(source_per_atom)
+                probs.append(num_atoms)
+                combo = openmc.data.combine_distributions(dists, probs)
+                for p,x in zip(combo.p, combo.x):
+                    if p>threshold:
+                        print('   ',p,x)
+                        energies_to_label.append(x)
+                        labels.append(nuc)
 
         lineid_plot.plot_line_ids(self.decay_photon_energy.x, self.decay_photon_energy.p, energies_to_label, labels)
-# my_material.nuclides[0]
-# NuclideTuple(name='Xe135', percent=1, percent_type='ao')
+
 
         
         # plt.plot()

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,12 +30,13 @@ install_requires=
     numpy >= 1.21.1
     plotly >= 5.1.0
     h5py
-    lineid_plot
     # openmc is also required but can't yet be installed by pip
 
 [options.extras_require]
 tests = 
     pytest >= 5.4.3
+extras =
+    lineid_plot
 
 [flake8]
 per-file-ignores = __init__.py:F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires=
     numpy >= 1.21.1
     plotly >= 5.1.0
     h5py
+    lineid_plot
     # openmc is also required but can't yet be installed by pip
 
 [options.extras_require]


### PR DESCRIPTION
allows gamma spec to be plotted, with optional labeling of most active energies


```python
import openmc
import openmc.deplete
import openmc_source_plotter  # adds plot_gamma_emission plot to materials

openmc.config["chain_file"] = "chain-endf.xml"

my_material = openmc.Material()
my_material.add_nuclide('Xe135', 1e-12)
my_material.add_nuclide('U235', 1)
my_material.add_nuclide('U238', 1)
my_material.add_nuclide('Co60', 1e-9)
my_material.volume = 1

plt = my_material.plot_gamma_emission(label_top=3)
plt.xscale('log') # modify axis from default settings
plt.savefig('gamma_spec.png')
```
![gamma_spec](https://user-images.githubusercontent.com/8583900/197498589-777df36b-9768-4037-b052-5f2b5c854a90.png)

