### PR TITLE
Work with openmc.stats.Mixture when plotting gamma spec

### DIFF
--- a/src/openmc_source_plotter/material.py
+++ b/src/openmc_source_plotter/material.py
@@ -1,16 +1,17 @@
 import openmc
 import matplotlib.pyplot as plt
 
+
 def _get_energy_prob(energy_dis):
     """gets the energy and probability for different openmc.stats including the
-     openmc.stats.Mixutre which itself is made from openmc.stats"""
+    openmc.stats.Mixutre which itself is made from openmc.stats"""
 
     if isinstance(energy_dis, openmc.stats.Mixture):
         stats = energy_dis.distribution
         multipliers = energy_dis.probability
     else:
         stats = [energy_dis]
-        multipliers = [1.]
+        multipliers = [1.0]
 
     probs = []
     en = []
@@ -19,7 +20,7 @@ def _get_energy_prob(energy_dis):
 
         for p in stat.p:
             probs.append(0)
-            probs.append(p*multiplier)
+            probs.append(p * multiplier)
             probs.append(0)
         for x in stat.x:
             en.append(x)
@@ -27,6 +28,7 @@ def _get_energy_prob(energy_dis):
             en.append(x)
 
     return en, probs
+
 
 def plot_gamma_emission(
     material,

--- a/src/openmc_source_plotter/material.py
+++ b/src/openmc_source_plotter/material.py
@@ -1,6 +1,32 @@
 import openmc
 import matplotlib.pyplot as plt
 
+def _get_energy_prob(energy_dis):
+    """gets the energy and probability for different openmc.stats including the
+     openmc.stats.Mixutre which itself is made from openmc.stats"""
+
+    if isinstance(energy_dis, openmc.stats.Mixture):
+        stats = energy_dis.distribution
+        multipliers = energy_dis.probability
+    else:
+        stats = [energy_dis]
+        multipliers = [1.]
+
+    probs = []
+    en = []
+
+    for stat, multiplier in zip(stats, multipliers):
+
+        for p in stat.p:
+            probs.append(0)
+            probs.append(p*multiplier)
+            probs.append(0)
+        for x in stat.x:
+            en.append(x)
+            en.append(x)
+            en.append(x)
+
+    return en, probs
 
 def plot_gamma_emission(
     material,
@@ -48,16 +74,9 @@ def plot_gamma_emission(
         probs = []
         en = []
         energy_dis = material.get_decay_photon_energy(clip_tolerance=0.0)
-        for p in energy_dis.p:
-            probs.append(0)
-            probs.append(p)
-            probs.append(0)
-        for x in energy_dis.x:
-            en.append(x)
-            en.append(x)
-            en.append(x)
-        # print(en)
-        # print(probs)
+
+        en, probs = _get_energy_prob(energy_dis)
+
         lineid_plot.plot_line_ids(
             en,
             # material.decay_photon_energy.x,
@@ -68,17 +87,9 @@ def plot_gamma_emission(
         )
 
     else:
-        probs = []
-        en = []
         energy_dis = material.get_decay_photon_energy(clip_tolerance=0.0)
-        for p in energy_dis.p:
-            probs.append(0)
-            probs.append(p)
-            probs.append(0)
-        for x in energy_dis.x:
-            en.append(x)
-            en.append(x)
-            en.append(x)
+
+        en, probs = _get_energy_prob(energy_dis)
 
         # plt.scatter(energy_dis.x, energy_dis.p)
         plt.plot(en, probs)


### PR DESCRIPTION
Sometimes the gamma distributions is not a simple openmc.stats.Tabular or an openmc.stats.Discrete it can be a more complex openmc.stats.Mixutre which itself contains stats distributions.

We need some extra code to handle such a case.

This bug wouldn't have been found or solved without the very useful minimal reproducible example made by @rlbarker on issue #41